### PR TITLE
Fix gnome-terminal (shell) styling

### DIFF
--- a/db16
+++ b/db16
@@ -99,10 +99,10 @@ function convertToBase16(output) {
 
   var scheme = {};
 
-  scheme['base00'] =
-    'FF0000';
-  scheme['base01'] =
-    'FFFF00';
+  scheme['base00'] = /* background - terminal */
+    getColor(rules, ':host', 'background-color'); /* #2a2734 */
+  scheme['base01'] = /* gutter,current line background - terminal */
+    getColor(rules, ':host .gutter .line-number.cursor-line', 'background-color');   /* #312e3d */
   scheme['base02'] = /* function names, variable names */
     getColor(rules, '.uno-3', 'color'); /* #a391fd */
   scheme['base03'] =


### PR DESCRIPTION
Background was appearing as `#FF0000` while the gutter was `#FFFF00`. These
have been replaced with the correctly mapped duotone colours.

Running this through [base16-builder-php](https://github.com/chriskempson/base16-builder-php) and the deprecated [base16-builder](https://github.com/chriskempson/base16-builder) appear to work fine. If this issue was occurring with other shells it should be fixed with this as well.

Dark (gnome-terminal):
![image](https://cloud.githubusercontent.com/assets/8467879/17454366/d0de5846-5be6-11e6-9997-2f032cea4b48.png)

Dark Earth (gnome-terminal):
![image](https://cloud.githubusercontent.com/assets/8467879/17454368/e2726e8a-5be6-11e6-90f0-0e11043f404c.png)

Dark Sea (gnome-terminal):
![image](https://cloud.githubusercontent.com/assets/8467879/17454361/ad1ed476-5be6-11e6-9af6-76c0465d5069.png)
